### PR TITLE
Update to work with Classic Wow

### DIFF
--- a/MrFish.xml
+++ b/MrFish.xml
@@ -1,7 +1,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
 	<Script file="MrFish.lua"/>
-	<ItemButton name="MrFishBaitButton" enableMouse="true" inherits="SecureActionButtonTemplate" virtual="true">
+	<Button name="MrFishBaitButton" enableMouse="true" inherits="SecureActionButtonTemplate,ItemButtonTemplate" virtual="true">
 		<Size x="32" y="32"/>
 		<Layers>
 			<Layer level="ARTWORK">
@@ -52,7 +52,7 @@
 			</OnEnter>
 			<OnLeave function="GameTooltip_Hide"/>
 		</Scripts>
-	</ItemButton>
+	</Button>
 	<Button name="MrFishButton" parent="UIParent"  movable="true" enableMouse="true" clampedToScreen="true" inherits="MoneyWonAlertFrameTemplate,SecureActionbuttonTemplate">
 		<Anchors>
 			<Anchor point="CENTER" x="0" y="0"/>

--- a/MrFish.xml
+++ b/MrFish.xml
@@ -1,7 +1,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
 	<Script file="MrFish.lua"/>
-	<Button name="MrFishBaitButton" enableMouse="true" inherits="SecureActionButtonTemplate,ItemButtonTemplate" virtual="true">
+	<Button name="MrFishBaitButton" enableMouse="true" inherits="SecureActionButtonTemplate" virtual="true">
 		<Size x="32" y="32"/>
 		<Layers>
 			<Layer level="ARTWORK">


### PR DESCRIPTION
Hi there,

I've updated your addon Mr. Fish to work with Classic Wow.
I added some events and version checks so it **should** also work with BfA.
Also changed the "Bait" button to directly apply the Bait to the Fishing Pole in Slot 16.

**BUT** i needed to revert the changes in your MrFish.xml becasue the type "ItemButton" is not existing in Classic.
I need to test it the next days in BfA too but i dont know why this should not work with the type "Button" -> but i also can be very wrong!

Should it not work with BfA in the XML file, maybe it is better to clone the AddOn for Classic and make an separate release for BfA and Classic.

Hopefully it is ok for you what i've done.

greetings,
fuba